### PR TITLE
install curl in swift Dockerfile

### DIFF
--- a/template/swift/Dockerfile
+++ b/template/swift/Dockerfile
@@ -2,6 +2,12 @@ FROM swift:latest
 
 WORKDIR /swift/src/handler
 
+RUN \
+    apt-get update && \
+    apt-get install -y curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN mkdir -p /app
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
The existing Dockerfile was mostly valid, but `swift:latest` no longer includes `curl`, so it needs to be installed. 